### PR TITLE
fix: Adjust heading level in filter.md

### DIFF
--- a/src/commands/misc/filter.md
+++ b/src/commands/misc/filter.md
@@ -1,4 +1,4 @@
-## Filtering snapshots
+# Filtering snapshots
 
 rustic allows to filter snapshots by certain criteria. This can be useful when
 listing snapshots, copying snapshots between repositories.


### PR DESCRIPTION
Changed the heading "## Filtering snapshots" to "# Filtering snapshots" in `src/commands/misc/filter.md` to ensure consistency with other top-level headings in the documentation.