### PR TITLE
Update rewrite command example in documentation

### DIFF
--- a/src/commands/misc/rewrite.md
+++ b/src/commands/misc/rewrite.md
@@ -170,7 +170,7 @@ And using the `--forget` option, we can do the `rewrite` and `forget` steps in
 one command:
 
 ```console
-$ rustic rewrite --forget --glob '!Project/config/secret.env' 5109f5fe ca466029
+$ rustic rewrite --forget --tags-rewritten '' --glob '!Project/config/secret.env' 5109f5fe ca466029
 $ rustic snapshots --all --filter-paths Project
 
 snapshots for (host [kasimir], label [], paths [Project])


### PR DESCRIPTION
As it is said:

`Interestingly, the new snapshots replaced the old ones but were not tagged. The options `--forget` and `--tags-rewritten ''` prevent the command from adding the `rewrite` tag.`

the mentioned `--tags-rewritten ''`  was missing in the example command