### PR TITLE
Fix invalid example rustic.toml

### DIFF
--- a/src/commands/init/configuration_file.md
+++ b/src/commands/init/configuration_file.md
@@ -52,7 +52,7 @@ keep-weekly = 5
 
 [backup]
 exclude-if-present = [".nobackup", "CACHEDIR.TAG"]
-glob-file = ["/root/rustic-local.glob"]
+glob-files = ["/root/rustic-local.glob"]
 
 [[backup.snapshots]]
 name = "home"


### PR DESCRIPTION
This should have been updated with rustic-rs/rustic_core#267